### PR TITLE
Fix daily interest calculation

### DIFF
--- a/backend/src/main/java/com/example/diary/model/Trade.java
+++ b/backend/src/main/java/com/example/diary/model/Trade.java
@@ -129,7 +129,11 @@ public class Trade {
         if (entryDate == null || exitDate == null || getDailyInterestAmount() == null) return result;
 
         LocalDate currentDate = entryDate;
-        while (!currentDate.isAfter(exitDate)) {
+        // Interest accrues for each day the position is held. Since
+        // ChronoUnit.DAYS.between(entryDate, exitDate) in getTotalInterest()
+        // excludes the exit date, we iterate until the day before exitDate to
+        // keep calculations consistent.
+        while (currentDate.isBefore(exitDate)) {
             DailyInterest daily = new DailyInterest();
             daily.setDate(currentDate);
             daily.setAmount(getDailyInterestAmount());


### PR DESCRIPTION
## Summary
- correct `getDailyInterestList` to exclude exit date so the total matches `getTotalInterest`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684071a70cb48324a94d3c04360e5e1d