### PR TITLE
Add Swagger UI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cd backend
 
 Приложение будет доступно по адресу: http://localhost:5173
 
-API документация: http://localhost:8081
+API документация: http://localhost:8081/api/swagger-ui.html
 
 ## Основные функции
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-ui</artifactId>
+      <version>1.7.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>runtime</scope>

--- a/backend/src/main/java/com/example/diary/config/OpenAPIConfig.java
+++ b/backend/src/main/java/com/example/diary/config/OpenAPIConfig.java
@@ -1,0 +1,19 @@
+package com.example.diary.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Trade Diary API")
+                        .description("API documentation for Trade Diary")
+                        .version("1.0.0"));
+    }
+}


### PR DESCRIPTION
## Summary
- document Swagger endpoint in README
- include `springdoc-openapi-ui` dependency
- configure an OpenAPI bean

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_684075eea13883248df4784c388d0f1c